### PR TITLE
Major performance optimizations for HFS+ DMG extraction

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,373 @@
+package apfs_test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blacktop/go-apfs/pkg/disk/dmg"
+	"github.com/blacktop/go-apfs/pkg/disk/hfsplus"
+)
+
+// TestDMG is the path to the test DMG file.
+// Download with: curl -L -o testdata/Fork.dmg https://cdn.fork.dev/mac/Fork-2.60.4.dmg
+const TestDMG = "testdata/Fork.dmg"
+
+func skipIfNoTestDMG(t testing.TB) {
+	if _, err := os.Stat(TestDMG); os.IsNotExist(err) {
+		t.Skipf("test DMG not found at %s - download with: curl -L -o testdata/Fork.dmg https://cdn.fork.dev/mac/Fork-2.60.4.dmg", TestDMG)
+	}
+}
+
+// BenchmarkDMGOpen measures the time to open and parse a DMG file.
+// This includes reading the footer, plist, and partition table.
+func BenchmarkDMGOpen(b *testing.B) {
+	skipIfNoTestDMG(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dmgFile, err := dmg.Open(TestDMG, &dmg.Config{})
+		if err != nil {
+			b.Fatalf("failed to open DMG: %v", err)
+		}
+		dmgFile.Close()
+	}
+}
+
+// BenchmarkHFSPlusMount measures the time to mount an HFS+ filesystem from a DMG.
+func BenchmarkHFSPlusMount(b *testing.B) {
+	skipIfNoTestDMG(b)
+
+	dmgFile, err := dmg.Open(TestDMG, &dmg.Config{})
+	if err != nil {
+		b.Fatalf("failed to open DMG: %v", err)
+	}
+	defer dmgFile.Close()
+
+	var hfsPartition *dmg.Partition
+	for i := range dmgFile.Partitions {
+		if strings.Contains(dmgFile.Partitions[i].Name, "Apple_HFS") {
+			hfsPartition = &dmgFile.Partitions[i]
+			break
+		}
+	}
+	if hfsPartition == nil {
+		b.Skip("no HFS+ partition found in DMG")
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hfs, err := hfsplus.New(hfsPartition)
+		if err != nil {
+			b.Fatalf("failed to mount HFS+: %v", err)
+		}
+		hfs.Close()
+	}
+}
+
+// BenchmarkHFSPlusListFiles measures the time to list all files in an HFS+ filesystem.
+// This is the most performance-critical operation for GAL.
+func BenchmarkHFSPlusListFiles(b *testing.B) {
+	skipIfNoTestDMG(b)
+
+	dmgFile, err := dmg.Open(TestDMG, &dmg.Config{})
+	if err != nil {
+		b.Fatalf("failed to open DMG: %v", err)
+	}
+	defer dmgFile.Close()
+
+	var hfsPartition *dmg.Partition
+	for i := range dmgFile.Partitions {
+		if strings.Contains(dmgFile.Partitions[i].Name, "Apple_HFS") {
+			hfsPartition = &dmgFile.Partitions[i]
+			break
+		}
+	}
+	if hfsPartition == nil {
+		b.Skip("no HFS+ partition found in DMG")
+	}
+
+	hfs, err := hfsplus.New(hfsPartition)
+	if err != nil {
+		b.Fatalf("failed to mount HFS+: %v", err)
+	}
+	defer hfs.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		files, err := hfs.Files()
+		if err != nil {
+			b.Fatalf("failed to list files: %v", err)
+		}
+		_ = files
+	}
+}
+
+// BenchmarkHFSPlusReadFile measures the time to read a specific file from an HFS+ filesystem.
+func BenchmarkHFSPlusReadFile(b *testing.B) {
+	skipIfNoTestDMG(b)
+
+	dmgFile, err := dmg.Open(TestDMG, &dmg.Config{})
+	if err != nil {
+		b.Fatalf("failed to open DMG: %v", err)
+	}
+	defer dmgFile.Close()
+
+	var hfsPartition *dmg.Partition
+	for i := range dmgFile.Partitions {
+		if strings.Contains(dmgFile.Partitions[i].Name, "Apple_HFS") {
+			hfsPartition = &dmgFile.Partitions[i]
+			break
+		}
+	}
+	if hfsPartition == nil {
+		b.Skip("no HFS+ partition found in DMG")
+	}
+
+	hfs, err := hfsplus.New(hfsPartition)
+	if err != nil {
+		b.Fatalf("failed to mount HFS+: %v", err)
+	}
+	defer hfs.Close()
+
+	files, err := hfs.Files()
+	if err != nil {
+		b.Fatalf("failed to list files: %v", err)
+	}
+
+	// Find a reasonably sized file to read (the main binary)
+	var targetFile *hfsplus.FileRecord
+	for _, f := range files {
+		if strings.HasSuffix(f.Path(), "/Fork") && f.FileInfo.DataFork.LogicalSize > 0 {
+			targetFile = f
+			break
+		}
+	}
+	if targetFile == nil {
+		// Fall back to any file with content
+		for _, f := range files {
+			if f.FileInfo.DataFork.LogicalSize > 1000 {
+				targetFile = f
+				break
+			}
+		}
+	}
+	if targetFile == nil {
+		b.Skip("no suitable file found for reading")
+	}
+
+	b.ResetTimer()
+	b.SetBytes(int64(targetFile.FileInfo.DataFork.LogicalSize))
+
+	for i := 0; i < b.N; i++ {
+		reader := targetFile.Reader()
+		if reader == nil {
+			b.Fatal("failed to get file reader")
+		}
+		_, err := io.Copy(io.Discard, reader)
+		if err != nil {
+			b.Fatalf("failed to read file: %v", err)
+		}
+	}
+}
+
+// BenchmarkFullExtraction measures the complete extraction workflow.
+// This is what GAL does: open DMG, mount, list, and extract all files.
+func BenchmarkFullExtraction(b *testing.B) {
+	skipIfNoTestDMG(b)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Open DMG
+		dmgFile, err := dmg.Open(TestDMG, &dmg.Config{})
+		if err != nil {
+			b.Fatalf("failed to open DMG: %v", err)
+		}
+
+		// Find HFS+ partition
+		var hfsPartition *dmg.Partition
+		for j := range dmgFile.Partitions {
+			if strings.Contains(dmgFile.Partitions[j].Name, "Apple_HFS") {
+				hfsPartition = &dmgFile.Partitions[j]
+				break
+			}
+		}
+		if hfsPartition == nil {
+			dmgFile.Close()
+			b.Skip("no HFS+ partition found")
+		}
+
+		// Mount HFS+
+		hfs, err := hfsplus.New(hfsPartition)
+		if err != nil {
+			dmgFile.Close()
+			b.Fatalf("failed to mount: %v", err)
+		}
+
+		// List all files
+		files, err := hfs.Files()
+		if err != nil {
+			hfs.Close()
+			dmgFile.Close()
+			b.Fatalf("failed to list: %v", err)
+		}
+
+		// Read first 10 files (simulate extraction)
+		count := 0
+		for _, f := range files {
+			if f.FileInfo.DataFork.LogicalSize > 0 {
+				reader := f.Reader()
+				if reader != nil {
+					io.Copy(io.Discard, reader)
+					count++
+					if count >= 10 {
+						break
+					}
+				}
+			}
+		}
+
+		hfs.Close()
+		dmgFile.Close()
+	}
+}
+
+// BenchmarkDMGReadAt measures random access read performance on the DMG.
+// This tests the LRU cache and decompression performance.
+func BenchmarkDMGReadAt(b *testing.B) {
+	skipIfNoTestDMG(b)
+
+	dmgFile, err := dmg.Open(TestDMG, &dmg.Config{})
+	if err != nil {
+		b.Fatalf("failed to open DMG: %v", err)
+	}
+	defer dmgFile.Close()
+
+	buf := make([]byte, 4096)
+
+	b.ResetTimer()
+	b.SetBytes(4096)
+
+	for i := 0; i < b.N; i++ {
+		// Read at various offsets to test cache behavior
+		offset := int64((i % 100) * 4096)
+		_, err := dmgFile.ReadAt(buf, offset)
+		if err != nil && err != io.EOF {
+			b.Fatalf("failed to read at offset %d: %v", offset, err)
+		}
+	}
+}
+
+// BenchmarkDMGReadAtSequential measures sequential read performance.
+func BenchmarkDMGReadAtSequential(b *testing.B) {
+	skipIfNoTestDMG(b)
+
+	dmgFile, err := dmg.Open(TestDMG, &dmg.Config{})
+	if err != nil {
+		b.Fatalf("failed to open DMG: %v", err)
+	}
+	defer dmgFile.Close()
+
+	buf := make([]byte, 4096)
+
+	b.ResetTimer()
+	b.SetBytes(4096)
+
+	offset := int64(0)
+	for i := 0; i < b.N; i++ {
+		_, err := dmgFile.ReadAt(buf, offset)
+		if err != nil && err != io.EOF {
+			b.Fatalf("failed to read at offset %d: %v", offset, err)
+		}
+		offset += 4096
+		// Wrap around to avoid running off the end
+		if offset > 10*1024*1024 {
+			offset = 0
+		}
+	}
+}
+
+// TestIntegrationExtractDMG is an integration test that extracts files from the DMG.
+// Run with: go test -v -run TestIntegrationExtractDMG
+func TestIntegrationExtractDMG(t *testing.T) {
+	skipIfNoTestDMG(t)
+
+	dmgFile, err := dmg.Open(TestDMG, &dmg.Config{})
+	if err != nil {
+		t.Fatalf("failed to open DMG: %v", err)
+	}
+	defer dmgFile.Close()
+
+	t.Logf("DMG opened successfully")
+	t.Logf("Partitions:")
+	for i, p := range dmgFile.Partitions {
+		t.Logf("  %d: %s", i, p.Name)
+	}
+
+	var hfsPartition *dmg.Partition
+	for i := range dmgFile.Partitions {
+		if strings.Contains(dmgFile.Partitions[i].Name, "Apple_HFS") {
+			hfsPartition = &dmgFile.Partitions[i]
+			break
+		}
+	}
+	if hfsPartition == nil {
+		t.Skip("no HFS+ partition found in DMG")
+	}
+
+	hfs, err := hfsplus.New(hfsPartition)
+	if err != nil {
+		t.Fatalf("failed to mount HFS+: %v", err)
+	}
+	defer hfs.Close()
+
+	files, err := hfs.Files()
+	if err != nil {
+		t.Fatalf("failed to list files: %v", err)
+	}
+
+	t.Logf("Found %d files", len(files))
+
+	// Create temp dir for extraction
+	tmpDir, err := os.MkdirTemp("", "go-apfs-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Extract a few files
+	extracted := 0
+	for _, f := range files {
+		if f.FileInfo.DataFork.LogicalSize > 0 && f.FileInfo.DataFork.LogicalSize < 1*1024*1024 {
+			reader := f.Reader()
+			if reader == nil {
+				continue
+			}
+
+			destPath := filepath.Join(tmpDir, f.Path())
+			if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+				continue
+			}
+
+			outFile, err := os.Create(destPath)
+			if err != nil {
+				continue
+			}
+
+			n, err := io.Copy(outFile, reader)
+			outFile.Close()
+
+			if err == nil {
+				t.Logf("Extracted %s (%d bytes)", f.Path(), n)
+				extracted++
+				if extracted >= 5 {
+					break
+				}
+			}
+		}
+	}
+
+	t.Logf("Successfully extracted %d files", extracted)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/ulikunitz/xz v0.5.15
 	github.com/vbauerster/mpb/v7 v7.5.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/tj/go-buffer v1.1.0/go.mod h1:iyiJpfFcR2B9sXu7KvjbT9fpM4mOelRSDTbntVj
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vbauerster/mpb/v7 v7.5.3 h1:BkGfmb6nMrrBQDFECR/Q7RkKCw7ylMetCb4079CGs4w=
 github.com/vbauerster/mpb/v7 v7.5.3/go.mod h1:i+h4QY6lmLvBNK2ah1fSreiw3ajskRlBp9AhY/PnuOE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/disk/hfsplus/hfsplus.go
+++ b/pkg/disk/hfsplus/hfsplus.go
@@ -447,7 +447,7 @@ func (fs *HFSPlus) readBTreeNodeAtOffset(offset int64, nodeSize int, forkData Fo
 			if err != nil {
 				return nil, fmt.Errorf("failed to read record: %v", err)
 			}
-			log.Debugf("read record: %s", record)
+			// NOTE: Avoid log.Debugf here as it allocates even when disabled
 		default:
 			return nil, fmt.Errorf("unsupported node kind: %s", node.Descriptor.Kind)
 		}

--- a/pkg/disk/hfsplus/hfsplus.go
+++ b/pkg/disk/hfsplus/hfsplus.go
@@ -407,18 +407,16 @@ func (fs *HFSPlus) readBTreeNodeAtOffset(offset int64, nodeSize int, forkData Fo
 		return node, nil // header nodes do not contain records.
 	}
 
-	deltas := make([]uint16, node.Descriptor.NumRecords)
-	if err := binary.Read(
-		io.NewSectionReader(
-			fs.device,
-			// The record offset array is stored at the end of the node.
-			offset+int64(nodeSize)-(2*int64(node.Descriptor.NumRecords)),
-			2*int64(node.Descriptor.NumRecords),
-		),
-		binary.BigEndian,
-		&deltas,
-	); err != nil {
+	// Read record offsets directly without binary.Read to avoid reflection
+	numRecords := int(node.Descriptor.NumRecords)
+	deltaBuf := make([]byte, 2*numRecords)
+	deltaOffset := offset + int64(nodeSize) - int64(2*numRecords)
+	if _, err := fs.device.ReadAt(deltaBuf, deltaOffset); err != nil {
 		return nil, fmt.Errorf("failed to read record offsets: %v", err)
+	}
+	deltas := make([]uint16, numRecords)
+	for i := 0; i < numRecords; i++ {
+		deltas[i] = binary.BigEndian.Uint16(deltaBuf[i*2 : i*2+2])
 	}
 	slices.Reverse(deltas) // offset deltas are stored in reverse order.
 
@@ -460,19 +458,22 @@ func (fs *HFSPlus) readBTreeNodeAtOffset(offset int64, nodeSize int, forkData Fo
 func (fs *HFSPlus) readBTRecordAt(offset int64) (record BTRecord, err error) {
 	sr := io.NewSectionReader(fs.device, offset, 1<<63-1)
 
-	var keyLength uint16
-	if err := binary.Read(sr, binary.BigEndian, &keyLength); err != nil {
+	// Read keyLength directly without binary.Read to avoid reflection allocations
+	var buf [4]byte
+	if _, err := sr.Read(buf[:2]); err != nil {
 		return nil, fmt.Errorf("failed to read key length: %v", err)
 	}
+	keyLength := binary.BigEndian.Uint16(buf[:2])
 
 	sr.Seek(int64(keyLength), io.SeekCurrent) // skip past key
 
-	var recordType RecordType
-	if err := binary.Read(sr, binary.BigEndian, &recordType); err != nil {
+	// Read recordType directly without binary.Read
+	if _, err := sr.Read(buf[:2]); err != nil {
 		return nil, fmt.Errorf("failed to read record type: %v", err)
 	}
+	recordType := RecordType(binary.BigEndian.Uint16(buf[:2]))
 
-	sr.Seek(-int64(keyLength+uint16(binary.Size(keyLength)))-int64(binary.Size(recordType)), io.SeekCurrent) // rewind to start of record
+	sr.Seek(-int64(keyLength+2)-2, io.SeekCurrent) // rewind to start of record
 
 	switch recordType {
 	case HFSPlusFolderRecord:


### PR DESCRIPTION
> [!IMPORTANT]
> This is stacked on #75 

Authored with Claude Code, this PR dramatically improves the performance of HFS+ filesystem extraction from DMG files. An internal operation has gone from taking 2+ minutes to 1.83s with these changes.

## Changes

- Added LRU caching to `Partition.ReadAt` to avoid re-decompressing the same chunks
- Fixed a bug in `DMG.ReadAt` where cache entries were never stored (cache.Add was in wrong branch)
- Added buffer pooling (`sync.Pool`) for decompression buffers to reduce GC pressure
- Removed debug logging in hot paths that caused allocations even when disabled
- Replaced `encoding/binary.Read` with direct byte parsing in performance-critical paths
- Added comprehensive benchmarks for DMG and HFS+ operations

## Performance Improvements

| Benchmark | Before | After | Improvement |
|-----------|--------|-------|-------------|
| HFS+ Mount | 10.2s / 46GB | 1.5ms / 1MB | **6,800x faster, 46,000x less memory** |
| HFS+ List Files | 10s / 44GB | 1.6ms / 1.1MB | **6,250x faster** |
| Full Extraction | 24s / 94GB | 41ms / 18MB | **585x faster, 5,200x less memory** |

## Root Cause

The primary issue was `Partition.ReadAt` (used by HFS+ code) had no caching - every read of a B-tree node would re-decompress the same DMG chunks repeatedly. A typical HFS+ mount would decompress the same blocks thousands of times, causing massive memory churn and 46GB of allocations for a 46MB DMG.

## Testing

All existing tests pass. Added new benchmarks using Fork.dmg to validate performance.